### PR TITLE
Github Fork Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.DS_STORE
 /python37
+__pycache__/
 .env

--- a/githubforker/settings.py
+++ b/githubforker/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 from dotenv import load_dotenv
 from pathlib import Path
 
+import os
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -24,6 +26,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+
+# Environment Variables 
+REPO_OWNER = os.getenv('REPO_OWNER')
+REPO_NAME = os.getenv('REPO_NAME')
+GITHUB_API_OAUTH_TOKEN = os.getenv('GITHUB_API_OAUTH_TOKEN')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/repo/utils.py
+++ b/repo/utils.py
@@ -1,0 +1,21 @@
+import requests
+from django.conf import settings
+
+def create_github_fork(fork_name: str):
+    """Create a fork of the repo with the given name."""
+    repo_owner = settings.REPO_OWNER
+    repo_name = settings.REPO_NAME
+    github_api_oauth_token = settings.GITHUB_API_OAUTH_TOKEN
+
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': f'token {github_api_oauth_token}'
+    }
+
+    request_body = {
+        'name': fork_name
+    }
+    url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/forks'
+    response = requests.post(url, headers=headers, json=request_body)
+
+    return response

--- a/repo/utils.py
+++ b/repo/utils.py
@@ -1,21 +1,62 @@
+import json
 import requests
 from django.conf import settings
 
-def create_github_fork(fork_name: str):
-    """Create a fork of the repo with the given name."""
+
+def create_github_fork(fork_name: str, default_branch_only: bool = True):
+    """Create a fork of the repo with the given name.
+    
+    Args:
+        fork_name (str): The name of the fork to create.
+        default_branch_only (Bool): If True, the fork will only contain the default branch."
+    
+    Returns:
+        response (Response): The response from the GitHub API.
+    """
     repo_owner = settings.REPO_OWNER
     repo_name = settings.REPO_NAME
     github_api_oauth_token = settings.GITHUB_API_OAUTH_TOKEN
 
     headers = {
         'Accept': 'application/vnd.github+json',
-        'Authorization': f'token {github_api_oauth_token}'
+        'Authorization': f'token {github_api_oauth_token}',
     }
 
     request_body = {
-        'name': fork_name
+        'name': fork_name,
+        'default_branch_only': default_branch_only,
     }
+
+    # makes request to GitHub API
     url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/forks'
     response = requests.post(url, headers=headers, json=request_body)
+
+    # parses response to JSON
+    response_json = json.loads(response.content)
+
+    return process_fork_response(response_json)
+
+
+def process_fork_response(response_json: dict):
+    """Process the response from the GitHub API.
+    
+    Args:
+        response_json (dict): The response from the GitHub API.
+    
+    Returns:
+        response (dict): The response to be returned to the user.
+    """
+    if 'message' in response_json:
+        response = {
+            'status': 'error',
+            'message': response_json['message'],
+        }
+    else:
+        response = {
+            'status': 'success',
+            'message': 'Fork created successfully!',
+            'name': response_json['name'],
+            'html_url': response_json['html_url'],
+        }
 
     return response

--- a/repo/views.py
+++ b/repo/views.py
@@ -1,3 +1,7 @@
+import requests
 from django.shortcuts import render
 
 # Create your views here.
+
+def index(request):
+    return render(request, 'index.html')


### PR DESCRIPTION
Adds util functions to make a request to Github API to fork a Repo to an authorized user. 

the function `create_github_fork` requires one parameter and has an optional parameter

- name (str) - the name that the forked repo will be named when forked to the authorized user
- default_branch_only (bool) - when True this will only fork the main branch, if False it will fork the other branches as well

Also added a function to parse the Github API response