### PR TITLE
API Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /python37
 __pycache__/
 .env
+
+*sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /python37
 __pycache__/
 .env
-
 *sqlite3

--- a/README.md
+++ b/README.md
@@ -34,4 +34,20 @@ from repo.utils import create_github_fork
 create_github_fork('name-of-fork')
 ```
 
-Still WIP so more will come
+The api endpoint to create a fork is as follows
+
+```
+repo/fork/
+```
+
+This endpoint will fork the specified repo in the .env file to the Authenticated Github User that the Personal Access Token belongs to
+
+In addition you it can accept query parameters to change certain settings related to the fork
+
+- `fork_name` - The name of the fork to create.
+- `default_branch_only` -  If True, the fork will only contain the default branch.
+
+Example:
+```
+repo/fork/?fork_name=somenameforthefork?default_branch_only=False
+```

--- a/githubforker/urls.py
+++ b/githubforker/urls.py
@@ -13,9 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path('repo/', include('repo.urls')),
 ]

--- a/repo/urls.py
+++ b/repo/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import url
+from . import views
+
+urlpatterns = [
+    url(r'^fork/$', views.GithubForkView.as_view(), name='fork'),
+]

--- a/repo/views.py
+++ b/repo/views.py
@@ -1,7 +1,37 @@
-import requests
+import json
+
+from django.conf import settings
+from django.http import HttpResponse
 from django.shortcuts import render
+from django.views import View
+from repo.utils import create_github_fork
 
-# Create your views here.
+class GithubForkView(View):
 
-def index(request):
-    return render(request, 'index.html')
+    def get(self, request):
+        """Create a fork of the repo using the same name as the original github repo.
+        It can also accept query parameters to customize the fork name and whether branches are forked as well.
+
+        Query Parameters:
+            fork_name (str): The name of the fork to create.
+            default_branch_only (Bool): If True, the fork will only contain the default branch.
+        
+        Returns:
+            response (Response): The response from the GitHub API.
+        """
+        query_params = request.GET
+        fork_name = query_params.get('fork_name') or settings.REPO_NAME
+        default_branch_only = query_params.get('default_branch_only')
+
+        fork_args = {
+            fork_name: fork_name
+        }
+
+        if default_branch_only:
+            fork_args.update({
+                'default_branch_only': default_branch_only
+            })
+        
+
+        response = create_github_fork(**fork_args)
+        return HttpResponse(json.dumps(response))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==3.2.18
 python-dotenv==0.21.1
+pytest==7.3.1


### PR DESCRIPTION
Added an Endpoint that utilizes `create_github_fork` to generate a fork when accessing a URL

The api endpoint to create a fork is as follows

```
repo/fork/
```

This endpoint will fork the specified repo in the .env file to the Authenticated Github User that the Personal Access Token belongs to

In addition you it can accept query parameters to change certain settings related to the fork

- `fork_name` - The name of the fork to create.
- `default_branch_only` -  If True, the fork will only contain the default branch.

Example:
```
repo/fork/?fork_name=somenameforthefork?default_branch_only=False
```