### PR TITLE
Small landing page

### DIFF
--- a/githubforker/repo/templates/repo/repo_fork.html
+++ b/githubforker/repo/templates/repo/repo_fork.html
@@ -1,0 +1,5 @@
+{% if not request.user.githubuserinfo and not request.user.githubuserinfo.github_access_token %}
+    <a href="{% url 'admin:repo_githubuserinfo_changelist' %}">Please add Github User Info</a>
+{% else %}
+    <a href="{% url 'fork' %}">Fork This Project's Repo!</a>
+{% endif %}

--- a/githubforker/repo/urls.py
+++ b/githubforker/repo/urls.py
@@ -3,5 +3,6 @@ from django.contrib.auth.decorators import login_required
 from . import views
 
 urlpatterns = [
+    url(r'^$', login_required(views.RepoForkView.as_view()), name='repo_fork_url'),
     url(r'^fork/$', login_required(views.GithubForkView.as_view()), name='fork'),
 ]

--- a/githubforker/repo/views.py
+++ b/githubforker/repo/views.py
@@ -7,9 +7,13 @@ from django.views import View
 from repo.decorators import check_for_github_access_token
 from repo.utils import create_github_fork
 
-import logging
 
-logger = logging.getLogger(__name__)
+class RepoForkView(View):
+
+    def get(self, request):
+        """Render the repo fork page."""
+        return render(request, 'repo/repo_fork.html')
+
 
 class GithubForkView(View):
 


### PR DESCRIPTION
Added a plain text page at `repo/` that will either display a hyper link to go to the forking URL or the `Github User Info` page depending on if the info is set properly